### PR TITLE
Bugfix/fixing self created conditions

### DIFF
--- a/DZunkeFeatureFlagsBundle.php
+++ b/DZunkeFeatureFlagsBundle.php
@@ -7,4 +7,11 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 class DZunkeFeatureFlagsBundle extends Bundle
 {
 
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new Conditions());
+    }
+
 }

--- a/DependencyInjection/Compiler/Conditions.php
+++ b/DependencyInjection/Compiler/Conditions.php
@@ -10,18 +10,12 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class Conditions implements CompilerPassInterface
 {
-
     /**
      * @param ContainerBuilder $container
      */
     public function process(ContainerBuilder $container)
     {
         $configs = $container->getExtensionConfig('d_zunke_feature_flags');
-
-        if (1 <= count($configs)) {
-            return;
-        }
-
         $config = reset($configs);
 
         $this->configureToggle($config, $container);
@@ -33,31 +27,23 @@ class Conditions implements CompilerPassInterface
      */
     private function configureToggle(array $config, ContainerBuilder $container)
     {
+        $config = $this->normalizeConfig($config);
+
         $definition = $container->getDefinition('dz.feature_flags.toggle');
         $definition->addMethodCall('setDefaultState', [$config['default']]);
 
         $this->fillConditionsBag($container);
 
         foreach ($config['flags'] as $name => $flagConfig) {
+            $flagConfig = $this->normalizeFlagConfig($flagConfig, $config['default']);
 
-            $flagDefinition = new Definition(
-                Flag::class, //'DZunke\FeatureFlagsBundle\Toggle\Flag',
-                [
-                    $name,
-                    new Reference('dz.feature_flags.conditions_bag'),
-                    $flagConfig['default']
-                ]
+            $flagDefinition = $this->createFlagDefinition(
+                $name,
+                new Reference('dz.feature_flags.conditions_bag'),
+                $flagConfig['default']
             );
 
-            foreach ($flagConfig['conditions_config'] as $condition => $config) {
-                $flagDefinition->addMethodCall(
-                    'addCondition',
-                    [
-                        $condition,
-                        $config
-                    ]
-                );
-            }
+            $this->processFlagConditions($flagDefinition, $flagConfig['conditions_config']);
 
             $container->setDefinition('dz.feature_flags.toggle.flag.' . $name, $flagDefinition);
             $definition->addMethodCall('addFlag', [$flagDefinition]);
@@ -81,6 +67,91 @@ class Conditions implements CompilerPassInterface
             $options = reset($options);
             $containerBag->addMethodCall('set', [$options['alias'], new Reference($service)]);
 
+        }
+    }
+
+    /**
+     * Normalize config object so it can always be processed even
+     * if there are values missing from the config object
+     *
+     * @param array|null $config
+     *
+     * @return array
+     */
+    private function normalizeConfig(array $config = null)
+    {
+        if (false === is_array($config)) {
+            $config = [];
+        }
+
+        if (true === array_key_exists('flags', $config) && false === is_array($config['flags'])) {
+            unset($config['flags']);
+        }
+
+        return array_merge([
+            'default' => true,
+            'flags' => [],
+        ], $config);
+    }
+
+    /**
+     * Normalizes flag config to prevent the code from breaking
+     * whenever a property or maybe multiple properties do not exist
+     *
+     * @param array|null $config
+     * @param bool $defaultActive
+     *
+     * @return array
+     */
+    private function normalizeFlagConfig(array $config = null, $defaultActive)
+    {
+        if (false === is_array($config)) {
+            $config = [];
+        }
+
+        if (true === array_key_exists('conditions_config', $config) && false === is_array($config['conditions_config'])) {
+            unset($config['conditions_config']);
+        }
+
+        return array_merge([
+            'default' => (bool) $defaultActive,
+            'conditions_config' => [],
+        ], $config);
+    }
+
+    /**
+     * @param string $name
+     * @param Reference $reference
+     * @param bool $default
+     *
+     * @return Definition
+     */
+    private function createFlagDefinition($name, Reference $reference, $default)
+    {
+        return new Definition(
+            Flag::class,
+            [
+                (string) $name,
+                $reference,
+                (bool) $default
+            ]
+        );
+    }
+
+    /**
+     * @param Definition $flag
+     * @param array $config
+     */
+    private function processFlagConditions(Definition $flag, array $config)
+    {
+        foreach($config as $condition => $optionalValues) {
+            $flag->addMethodCall(
+                'addCondition',
+                [
+                    $condition,
+                    $optionalValues
+                ]
+            );
         }
     }
 }

--- a/DependencyInjection/Compiler/Conditions.php
+++ b/DependencyInjection/Compiler/Conditions.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace DZunke\FeatureFlagsBundle\DependencyInjection\Compiler;
+
+use DZunke\FeatureFlagsBundle\Toggle\Flag;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class Conditions implements CompilerPassInterface
+{
+
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $configs = $container->getExtensionConfig('d_zunke_feature_flags');
+
+        if (1 <= count($configs)) {
+            return;
+        }
+
+        $config = reset($configs);
+
+        $this->configureToggle($config, $container);
+    }
+
+    /**
+     * @param array $config
+     * @param ContainerBuilder $container
+     */
+    private function configureToggle(array $config, ContainerBuilder $container)
+    {
+        $definition = $container->getDefinition('dz.feature_flags.toggle');
+        $definition->addMethodCall('setDefaultState', [$config['default']]);
+
+        $this->fillConditionsBag($container);
+
+        foreach ($config['flags'] as $name => $flagConfig) {
+
+            $flagDefinition = new Definition(
+                Flag::class, //'DZunke\FeatureFlagsBundle\Toggle\Flag',
+                [
+                    $name,
+                    new Reference('dz.feature_flags.conditions_bag'),
+                    $flagConfig['default']
+                ]
+            );
+
+            foreach ($flagConfig['conditions_config'] as $condition => $config) {
+                $flagDefinition->addMethodCall(
+                    'addCondition',
+                    [
+                        $condition,
+                        $config
+                    ]
+                );
+            }
+
+            $container->setDefinition('dz.feature_flags.toggle.flag.' . $name, $flagDefinition);
+            $definition->addMethodCall('addFlag', [$flagDefinition]);
+        }
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     */
+    private function fillConditionsBag(ContainerBuilder $container)
+    {
+        $taggedConditions = $container->findTaggedServiceIds('dz.feature_flags.toggle.condition');
+
+        if (empty($taggedConditions)) {
+            return;
+        }
+
+        $containerBag = $container->getDefinition('dz.feature_flags.conditions_bag');
+
+        foreach ($taggedConditions as $service => $options) {
+            $options = reset($options);
+            $containerBag->addMethodCall('set', [$options['alias'], new Reference($service)]);
+
+        }
+    }
+}

--- a/DependencyInjection/DZunkeFeatureFlagsExtension.php
+++ b/DependencyInjection/DZunkeFeatureFlagsExtension.php
@@ -4,13 +4,16 @@ namespace DZunke\FeatureFlagsBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class DZunkeFeatureFlagsExtension extends Extension
 {
+
+    /**
+     * @param array $configs
+     * @param ContainerBuilder $container
+     */
     public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = $this->getConfiguration($configs, $container);
@@ -20,59 +23,6 @@ class DZunkeFeatureFlagsExtension extends Extension
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
-
-        $this->configureToogle($config, $container);
-    }
-
-    /**
-     * @param array            $config
-     * @param ContainerBuilder $container
-     */
-    protected function configureToogle(array $config, ContainerBuilder $container)
-    {
-        $definition = $container->getDefinition('dz.feature_flags.toggle');
-        $definition->addMethodCall('setDefaultState', [$config['default']]);
-
-        $this->fillConditionsBag($container);
-
-        foreach ($config['flags'] as $name => $flagConfig) {
-            $flagDefinition = new Definition(
-                'DZunke\FeatureFlagsBundle\Toggle\Flag',
-                [
-                    $name,
-                    new Reference('dz.feature_flags.conditions_bag'),
-                    $flagConfig['default']
-                ]
-            );
-
-            foreach ($flagConfig['conditions_config'] as $condition => $config) {
-                $flagDefinition->addMethodCall(
-                    'addCondition',
-                    [
-                        $condition,
-                        $config
-                    ]
-                );
-            }
-
-            $container->setDefinition('dz.feature_flags.toggle.flag.' . $name, $flagDefinition);
-            $definition->addMethodCall('addFlag', [$flagDefinition]);
-        }
-    }
-
-    protected function fillConditionsBag(ContainerBuilder $container)
-    {
-        $taggedConditions = $container->findTaggedServiceIds('dz.feature_flags.toggle.condition');
-        if (!empty($taggedConditions)) {
-            $containerBag = $container->getDefinition('dz.feature_flags.conditions_bag');
-
-            foreach ($taggedConditions as $service => $options) {
-
-                $options = reset($options);
-                $containerBag->addMethodCall('set', [$options['alias'], new Reference($service)]);
-
-            }
-        }
     }
 
 }

--- a/Toggle.php
+++ b/Toggle.php
@@ -10,7 +10,7 @@ class Toggle
     /**
      * @var bool
      */
-    private $defaultState = true;
+    private $defaultState;
 
     /**
      * @var Flag[]


### PR DESCRIPTION
Conditions that were made in other than the default bundle were never going to work. The searching of all services with a specific tag name needs to be done in a compiles pass object (which modifies the container at one of the last possible moments before the controllers are called)